### PR TITLE
Update StoredTab to SwiftData model

### DIFF
--- a/Aura 2.0/Core/Storage/Spaces/SpaceData.swift
+++ b/Aura 2.0/Core/Storage/Spaces/SpaceData.swift
@@ -25,9 +25,9 @@ final class SpaceData {
     // The color gradient of the background as hex codes
     var spaceBackgroundColors: [String]
     
-    var primaryTabs: [StoredTab] = []
-    var pinnedTabs: [StoredTab] = []
-    var favoriteTabs: [StoredTab] = []
+    @Relationship(deleteRule: .cascade) var primaryTabs: [StoredTab] = []
+    @Relationship(deleteRule: .cascade) var pinnedTabs: [StoredTab] = []
+    @Relationship(deleteRule: .cascade) var favoriteTabs: [StoredTab] = []
     
     init(
         spaceIdentifier: String,

--- a/Aura 2.0/Core/Storage/StoredTab.swift
+++ b/Aura 2.0/Core/Storage/StoredTab.swift
@@ -10,11 +10,27 @@
 
 import Foundation
 import SwiftData
-import WebKit
 
-struct StoredTab: @MainActor Codable, Hashable {
+@Model
+final class StoredTab {
     var uuid: UUID = UUID()
     var timestamp: Date
     var url: String
     var tabType: TabType
+
+    @Relationship var parentSpace: SpaceData?
+
+    init(
+        uuid: UUID = UUID(),
+        timestamp: Date,
+        url: String,
+        tabType: TabType,
+        parentSpace: SpaceData? = nil
+    ) {
+        self.uuid = uuid
+        self.timestamp = timestamp
+        self.url = url
+        self.tabType = tabType
+        self.parentSpace = parentSpace
+    }
 }

--- a/Aura 2.0/Core/Storage/TabType.swift
+++ b/Aura 2.0/Core/Storage/TabType.swift
@@ -8,9 +8,9 @@
 //
 
 
-import SwiftUI
+import Foundation
 
-enum TabType: @MainActor Codable {
+enum TabType: String, Codable {
     case primary
     case pinned
     case favorites

--- a/Aura 2.0/Core/ViewModels/StorageManager.swift
+++ b/Aura 2.0/Core/ViewModels/StorageManager.swift
@@ -99,7 +99,8 @@ class StorageManager: ObservableObject {
         let storedTabObject = StoredTab(
             timestamp: Date.now,
             url: formattedURL,
-            tabType: .primary
+            tabType: .primary,
+            parentSpace: space
         )
         
         // Add to the space's storedTabs and persist

--- a/Aura 2.0/UI/Sidebar.swift
+++ b/Aura 2.0/UI/Sidebar.swift
@@ -68,10 +68,7 @@ struct Sidebar: View {
                                                 await storageManager.selectOrLoadTab(tabObject: tab)
                                                 
                                                 if let index = selectedSpace.primaryTabs.firstIndex(where: { $0.uuid == tab.uuid }) {
-                                                    var updatedTabs = selectedSpace.primaryTabs
-                                                    updatedTabs[index].timestamp = Date.now
-                                                    selectedSpace.primaryTabs = updatedTabs
-
+                                                    selectedSpace.primaryTabs[index].timestamp = Date.now
                                                     try? modelContext.save()
                                                 }
                                             }


### PR DESCRIPTION
## Summary
- convert `StoredTab` to an `@Model` class
- allow `SpaceData` to own `StoredTab` objects via relationships
- make `TabType` Codable with a raw `String` backing
- set the tab's `parentSpace` when creating new tabs
- update sidebar timestamp handling for reference semantics

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684bae3d89a8832da39cad7f3c468636