### PR TITLE
Refactor StoredTab to SwiftData model

### DIFF
--- a/Aura 2.0/Core/Storage/Spaces/SpaceData.swift
+++ b/Aura 2.0/Core/Storage/Spaces/SpaceData.swift
@@ -29,8 +29,11 @@ final class SpaceData {
     var textColor: String
     var adaptiveTheme: Bool = false
     
+    @Relationship(deleteRule: .cascade, inverse: \StoredTab.parentSpace)
     var primaryTabs: [StoredTab] = []
+    @Relationship(deleteRule: .cascade, inverse: \StoredTab.parentSpace)
     var pinnedTabs: [StoredTab] = []
+    @Relationship(deleteRule: .cascade, inverse: \StoredTab.parentSpace)
     var favoriteTabs: [StoredTab] = []
     
     init(
@@ -38,18 +41,12 @@ final class SpaceData {
         spaceName: String,
         isIncognito: Bool,
         spaceBackgroundColors: [String],
-        textColor: String,
-        primaryTabs: [StoredTab] = [],
-        pinnedTabs: [StoredTab] = [],
-        favoriteTabs: [StoredTab] = []
+        textColor: String
     ) {
         self.spaceIdentifier = spaceIdentifier
         self.spaceName = spaceName
         self.isIncognito = isIncognito
         self.spaceBackgroundColors = spaceBackgroundColors
         self.textColor = textColor
-        self.primaryTabs = primaryTabs
-        self.pinnedTabs = pinnedTabs
-        self.favoriteTabs = favoriteTabs
     }
 }

--- a/Aura 2.0/Core/Storage/StoredTab.swift
+++ b/Aura 2.0/Core/Storage/StoredTab.swift
@@ -1,28 +1,36 @@
-//
-// Aura 2.0
-// Item.swift
-//
-// Created on 6/10/25
-//
-// Copyright ©2025 DoorHinge Apps.
-//
-
-
 import Foundation
 import SwiftData
-import WebKit
 
-struct StoredTab: @MainActor Codable, Hashable {
-//    var uuid: UUID = UUID()
+/// A persisted representation of a browser tab.
+@Model
+final class StoredTab {
     var id: String
     var timestamp: Date
     var url: String
     var tabType: TabType
     var folderName: String?
+
+    /// The space that owns this tab.
+    @Relationship var parentSpace: SpaceData?
+
+    init(id: String,
+         timestamp: Date,
+         url: String,
+         tabType: TabType,
+         folderName: String? = nil,
+         parentSpace: SpaceData? = nil) {
+        self.id = id
+        self.timestamp = timestamp
+        self.url = url
+        self.tabType = tabType
+        self.folderName = folderName
+        self.parentSpace = parentSpace
+    }
 }
 
+/// Generates a unique identifier for a stored tab using the url and date.
 func createStoredTabID(url: String) -> String {
     let date = Date.now
-    var id = url + date.hashValue.description
+    let id = url + date.hashValue.description
     return id
 }

--- a/Aura 2.0/Core/Storage/TabType.swift
+++ b/Aura 2.0/Core/Storage/TabType.swift
@@ -10,7 +10,9 @@
 
 import SwiftUI
 
-enum TabType: @MainActor Codable {
+/// Type of a stored tab. Uses a `String` raw value so it can be
+/// persisted by SwiftData.
+enum TabType: String, Codable {
     case primary
     case pinned
     case favorites

--- a/Aura 2.0/Core/ViewModels/StorageManager.swift
+++ b/Aura 2.0/Core/ViewModels/StorageManager.swift
@@ -40,7 +40,10 @@ class StorageManager: ObservableObject {
             request.attribution = .user
             page.load(request)
 
-        let stored = StoredTab(id: createStoredTabID(url: url), timestamp: .now, url: url, tabType: .primary)
+        let stored = StoredTab(id: createStoredTabID(url: url),
+                               timestamp: .now,
+                               url: url,
+                               tabType: .primary)
             let tab = BrowserTab(lastActiveTime: .now, tabType: .primary, page: page, storedTab: stored)
             return tab
         }
@@ -136,10 +139,12 @@ class StorageManager: ObservableObject {
             id: createStoredTabID(url: formattedURL),
             timestamp: Date.now,
             url: formattedURL,
-            tabType: .primary
+            tabType: .primary,
+            parentSpace: space
         )
-        
+
         // Add to the space's storedTabs and persist
+        modelContext.insert(storedTabObject)
         space.primaryTabs.append(storedTabObject)
         try? modelContext.save()
         

--- a/Aura 2.0/UI/Sidebar Components/Sidebar.swift
+++ b/Aura 2.0/UI/Sidebar Components/Sidebar.swift
@@ -172,7 +172,7 @@ struct Sidebar: View {
                                     }.keyboardShortcut("t", modifiers: .command)
                                     
                                     // MARK: - Primary Tabs
-                                    ForEach(space.primaryTabs, id:\.self) { tab in
+                                    ForEach(space.primaryTabs, id: \.id) { tab in
                                         ZStack {
                                             RoundedRectangle(cornerRadius: 15)
                                                 .fill(Color.white.opacity(0.001))
@@ -209,13 +209,8 @@ struct Sidebar: View {
                                             Task {
                                                 await storageManager.selectOrLoadTab(tabObject: tab)
                                                 
-                                                if let index = space.primaryTabs.firstIndex(where: { $0.id == tab.id }) {
-                                                    var updatedTabs = space.primaryTabs
-                                                    updatedTabs[index].timestamp = Date.now
-                                                    space.primaryTabs = updatedTabs
-
-                                                    try? modelContext.save()
-                                                }
+                                                tab.timestamp = Date.now
+                                                try? modelContext.save()
                                             }
                                             uiViewModel.currentSelectedTab = tab.id
                                         }


### PR DESCRIPTION
## Summary
- refactor `StoredTab` struct into `@Model` class and add parent `SpaceData` link
- make `TabType` persistable via `String` raw value
- use `@Relationship` for tab collections in `SpaceData`
- update tab creation to assign a parent space and persist
- simplify timestamp updates after selecting a tab

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68528e3db908832d9ea6e3e472a7b071