### PR TITLE
Improve tab reordering behavior

### DIFF
--- a/Aura 2.0/Core/DragAndDrop/TabDragItem.swift
+++ b/Aura 2.0/Core/DragAndDrop/TabDragItem.swift
@@ -1,0 +1,15 @@
+import Foundation
+import UniformTypeIdentifiers
+import SwiftUI
+
+struct TabDragItem: Transferable, Codable, Equatable {
+    var id: String
+
+    static var transferRepresentation: some TransferRepresentation {
+        CodableRepresentation(contentType: .tabDragItem)
+    }
+}
+
+extension UTType {
+    static let tabDragItem = UTType(exportedAs: "com.doorhingeapps.tabdragitem")
+}

--- a/Aura 2.0/Core/DragAndDrop/TabDropDelegate.swift
+++ b/Aura 2.0/Core/DragAndDrop/TabDropDelegate.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import SwiftData
+
+struct TabDropDelegate: DropDelegate {
+    let tab: StoredTab
+    @Binding var tabs: [StoredTab]
+    @Binding var draggedTab: StoredTab?
+    var modelContext: ModelContext
+
+    func dropEntered(info: DropInfo) {
+        guard let dragged = draggedTab,
+              dragged != tab,
+              let from = tabs.firstIndex(of: dragged),
+              let to = tabs.firstIndex(of: tab) else { return }
+
+        // Real-time reorder preview
+        withAnimation {
+            tabs.move(fromOffsets: IndexSet(integer: from), toOffset: to)
+            updateOrder()
+        }
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        draggedTab = nil
+        updateOrder()
+        try? modelContext.save()
+        return true
+    }
+
+    private func updateOrder() {
+        for (idx, t) in tabs.enumerated() {
+            t.orderIndex = idx
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create transferable for tab dragging so iOS doesn't try to spawn a new window
- add custom drop delegate for live preview
- update sidebar to use the new drag and drop logic

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685457b94f64832d8296ad0c9c2a55ef